### PR TITLE
Usage postal_town as alternative of locality to set city field

### DIFF
--- a/src/PlaceSimpleFactory.php
+++ b/src/PlaceSimpleFactory.php
@@ -150,6 +150,20 @@ class PlaceSimpleFactory
      */
     protected function setLocality(array $component, Place $place): Place
     {
+        $place->setCity($component['long_name']);
+
+        return $place;
+    }
+
+    /**
+     * Postal town as alternative data if locality isn't present
+     *
+     * @param mixed[] $component
+     * @param Place   $place
+     * @return Place
+     */
+    protected function setPostalTown(array $component, Place $place): Place
+    {
         if ($place->getCity() === null) {
             $place->setCity($component['long_name']);
         }


### PR DESCRIPTION
There are situation when locality is not present in address_components types.
So, as alternative we might use a postal_town for better search experience.