### PR TITLE
Preferred language of address components and replacing values with higher "rank"

### DIFF
--- a/src/MapsCity.php
+++ b/src/MapsCity.php
@@ -40,7 +40,7 @@ class MapsCity
      * @param float $latitude
      * @param float $longitude
      *
-     * @return null|string
+     * @return string|null
      */
     public function getCityByCoordinates(float $latitude, float $longitude): ?string
     {

--- a/src/MapsPlace.php
+++ b/src/MapsPlace.php
@@ -152,7 +152,7 @@ class MapsPlace implements CacheInterface
     private function getApiUrl(): string
     {
         return \sprintf(
-            'https://maps.googleapis.com/maps/api/geocode/json?%s=%s&key=%s',
+            'https://maps.googleapis.com/maps/api/geocode/json?%s=%s&key=%s&language=en',
             $this->queryType,
             $this->query,
             $this->apiKey

--- a/src/MapsPlace.php
+++ b/src/MapsPlace.php
@@ -81,9 +81,9 @@ class MapsPlace implements CacheInterface
 
     /**
      * @param string $address
-     *
      * @param bool   $checkByPoint
-     * @return null|Place
+     *
+     * @return Place|null
      */
     public function getPlaceByAddress(string $address, bool $checkByPoint = true): ?Place
     {
@@ -143,7 +143,9 @@ class MapsPlace implements CacheInterface
      */
     protected function getClient(): Client
     {
-        return ($this->client instanceof Client) ? $this->client : new Client();
+        return $this->client instanceof Client
+            ? $this->client
+            : new Client();
     }
 
     /**
@@ -181,6 +183,7 @@ class MapsPlace implements CacheInterface
 
         if (!\is_array($googleData) || !$this->isGetPlaceResultCorrect($googleData)) {
             $googleData = $this->cache->updateData($obj);
+
             if (!\is_array($googleData) || !$this->isGetPlaceResultCorrect($googleData)) {
                 throw new \Exception(\sprintf('Place with query %s was not found', $obj->query));
             }
@@ -192,7 +195,7 @@ class MapsPlace implements CacheInterface
     /**
      * @param MapsPlace $obj
      * @param bool      $checkByPoint
-     * @return null|Place
+     * @return Place|null
      */
     private function getPlaceByObject(MapsPlace $obj, bool $checkByPoint): ?Place
     {
@@ -200,6 +203,7 @@ class MapsPlace implements CacheInterface
             $googleData = $this->getValidatedCacheData($obj);
 
             $place = $this->factory->createPlace($googleData['results']);
+
             if ($place === null) {
                 return null;
             }

--- a/src/Objects/Place.php
+++ b/src/Objects/Place.php
@@ -7,73 +7,119 @@ namespace Rentberry\MapsUtils\Objects;
  */
 class Place
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $id;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $locationLat;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $locationLng;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $locationType;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $boundsNortheastLat;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $boundsNortheastLng;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $boundsSouthwestLat;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $boundsSouthwestLng;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $viewportNortheastLat;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $viewportNortheastLng;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $viewportSouthwestLat;
 
-    /** @var float */
+    /**
+     * @var float
+     */
     protected $viewportSouthwestLng;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $formattedAddress;
 
-    /** @var mixed[] */
+    /**
+     * @var mixed[]
+     */
     protected $types;
 
-    /** @var mixed[] */
+    /**
+     * @var mixed[]
+     */
     protected $addressComponents;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $streetNumber;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $street;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $city;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $state;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $zip;
 
-    /** @var mixed[] */
+    /**
+     * @var mixed[]
+     */
     protected $source;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $shortAddress;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $url;
 
     /**
@@ -616,7 +662,7 @@ class Place
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getMainNeighborhood(): ?string
     {
@@ -624,7 +670,7 @@ class Place
     }
 
     /**
-     * @param null|string $mainNeighborhood
+     * @param string|null $mainNeighborhood
      *
      * @return Place
      */

--- a/src/PlaceSimpleFactory.php
+++ b/src/PlaceSimpleFactory.php
@@ -122,9 +122,7 @@ class PlaceSimpleFactory
      */
     protected function setStreetNumber(array $component, Place $place): Place
     {
-        if ($place->getStreetNumber() === null) {
-            $place->setStreetNumber($component['long_name']);
-        }
+        $place->setStreetNumber($component['long_name']);
 
         return $place;
     }
@@ -136,9 +134,7 @@ class PlaceSimpleFactory
      */
     protected function setRoute(array $component, Place $place): Place
     {
-        if ($place->getStreet() === null) {
-            $place->setStreet($component['short_name']);
-        }
+        $place->setStreet($component['short_name']);
 
         return $place;
     }
@@ -164,9 +160,7 @@ class PlaceSimpleFactory
      */
     protected function setPostalTown(array $component, Place $place): Place
     {
-        if ($place->getCity() === null) {
-            $place->setCity($component['long_name']);
-        }
+        $place->setCity($component['long_name']);
 
         return $place;
     }
@@ -178,9 +172,7 @@ class PlaceSimpleFactory
      */
     protected function setAdministrativeAreaLevel1(array $component, Place $place): Place
     {
-        if ($place->getState() === null) {
-            $place->setState($component['short_name']);
-        }
+        $place->setState($component['short_name']);
 
         return $place;
     }
@@ -192,9 +184,7 @@ class PlaceSimpleFactory
      */
     protected function setPostalCode(array $component, Place $place): Place
     {
-        if ($place->getZip() === null) {
-            $place->setZip($component['long_name']);
-        }
+        $place->setZip($component['long_name']);
 
         return $place;
     }
@@ -206,9 +196,7 @@ class PlaceSimpleFactory
      */
     protected function setSublocality(array $component, Place $place): Place
     {
-        if ($place->getSublocality() === null) {
-            $place->setSublocality($component['long_name']);
-        }
+        $place->setSublocality($component['long_name']);
 
         return $place;
     }

--- a/src/PlaceSimpleFactory.php
+++ b/src/PlaceSimpleFactory.php
@@ -34,7 +34,7 @@ class PlaceSimpleFactory
      * Fields can be not set if not valid googleDataResults provided.
      *
      * @param mixed[] $googleDataResults
-     * @return null|Place
+     * @return Place|null
      */
     public function createPlace(array $googleDataResults): ?Place
     {
@@ -82,6 +82,7 @@ class PlaceSimpleFactory
         foreach ($compositeComponents as $component) {
             foreach ($component['types'] as $type) {
                 $setter = 'set'.$this->camelize($type);
+
                 if (\method_exists($this, $setter)) {
                     $place = $this->$setter($component, $place);
                 }
@@ -101,6 +102,7 @@ class PlaceSimpleFactory
     protected function setMainNeighborhood(array $googleDataResults, Place $place): Place
     {
         $firstResult = $googleDataResults[0];
+
         foreach ($firstResult['address_components'] as $component) {
             foreach ($component['types'] as $type) {
                 if ($type === 'neighborhood' && !$place->getMainNeighborhood()) {
@@ -108,6 +110,7 @@ class PlaceSimpleFactory
                 }
             }
         }
+
         if (!$place->getMainNeighborhood() && $place->getNeighborhoods() !== null) {
             $place->setMainNeighborhood($place->getNeighborhoods()[0]);
         }
@@ -215,6 +218,7 @@ class PlaceSimpleFactory
         if (!\in_array($component['long_name'], $neighborhoods)) {
             $neighborhoods[] = $component['long_name'];
         }
+
         $place->setNeighborhoods($neighborhoods);
 
         return $place;
@@ -224,7 +228,6 @@ class PlaceSimpleFactory
      * Basic data such as geometry or types, etc. - provided only
      * with first result (basic for this place). So from $googleDataResults
      * retrieved first element (always!)
-     *
      *
      * @param mixed[] $googleDataResults
      * @param Place   $place

--- a/src/SearchMapsPlace.php
+++ b/src/SearchMapsPlace.php
@@ -27,8 +27,8 @@ class SearchMapsPlace
     /**
      * @param string      $city
      * @param string      $zip
-     * @param null|string $state
-     * @param null|string $country
+     * @param string|null $state
+     * @param string|null $country
      *
      * @return Place|null
      */
@@ -45,8 +45,8 @@ class SearchMapsPlace
 
     /**
      * @param string      $city
-     * @param null|string $state
-     * @param null|string $country
+     * @param string|null $state
+     * @param string|null $country
      *
      * @return Place|null
      */
@@ -63,9 +63,9 @@ class SearchMapsPlace
     /**
      * @param string      $neighborhood
      * @param string      $city
-     * @param null|string $state
-     * @param null|string $sublocality
-     * @param null|string $country
+     * @param string|null $state
+     * @param string|null $sublocality
+     * @param string|null $country
      *
      * @return Place|null
      */
@@ -84,8 +84,8 @@ class SearchMapsPlace
     /**
      * @param string      $sublocality
      * @param string      $city
-     * @param null|string $state
-     * @param null|string $country
+     * @param string|null $state
+     * @param string|null $country
      *
      * @return Place|null
      */


### PR DESCRIPTION
Hardcoded preferred language (english) in google api url. In Factory removed conditions for empty value for replacing values by data from higher level of component type.

This is done because more detailed type of result (point_of_interests, street_address) of geocoding  has no translation for separate `address_component` (for example `administrative_area_level_1` in Madrid will be "Comunidad de Madrid").

But more abstract type of result, such as `sublocality` for example, will have a translation, so we will have a translated to english and the same component `administrative_area_level_1` will be now "Community of Madrid".